### PR TITLE
ASD-788: Magento Swagger crashes due to parameter notation in API int…

### DIFF
--- a/Api/CheckoutSessionManagementInterface.php
+++ b/Api/CheckoutSessionManagementInterface.php
@@ -21,7 +21,7 @@ namespace Amazon\Pay\Api;
 interface CheckoutSessionManagementInterface
 {
     /**
-     * @param mixed|null $cartId
+     * @param string|null $cartId
      * @return mixed
      */
     public function getConfig($cartId = null);


### PR DESCRIPTION
…erface

Fixes # .

#### Additional details about this PR