### PR TITLE
ASD-817 - Prevent escaping special characters in Pay Now button payloads

### DIFF
--- a/Model/Adapter/AmazonPayAdapter.php
+++ b/Model/Adapter/AmazonPayAdapter.php
@@ -599,7 +599,7 @@ class AmazonPayAdapter
             $payload['addressDetails'] = $addressData;
         }
 
-        return json_encode($payload, JSON_UNESCAPED_SLASHES);
+        return json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     public function signButton($payload, $storeId = null)


### PR DESCRIPTION
Fixes [GH Issue #1086](https://github.com/amzn/amazon-payments-magento-2-plugin/issues/1086).