### PR TITLE
Exit _draw on button render error

### DIFF
--- a/view/frontend/web/js/amazon-button.js
+++ b/view/frontend/web/js/amazon-button.js
@@ -132,7 +132,12 @@ define([
                     this._loadButtonConfig(function (buttonConfig) {
                         // do not use session config for decoupled button
                         delete buttonConfig.createCheckoutSessionConfig;
-                        var amazonPayButton = amazon.Pay.renderButton('#' + $buttonRoot.empty().removeUniqueId().uniqueId().attr('id'), buttonConfig);
+                        try {
+                            var amazonPayButton = amazon.Pay.renderButton('#' + $buttonRoot.empty().removeUniqueId().uniqueId().attr('id'), buttonConfig);
+                        } catch (e) {
+                            console.log('Amazon Pay button render error: ' + e);
+                            return;
+                        }
                         amazonPayButton.onClick(function() {
                             if (self.buttonType === 'PayNow' && !additionalValidators.validate()) {
                                 return false;


### PR DESCRIPTION
We should only have an exception from the amazon.Pay.renderButton in a couple of cases:

1. The buttonContainer we are trying to render to no longer exists, likely meaning our button template has been re-rendered/the shortcut_buttons_container event has been observed again.
2. Possible incorrect values in the buttonConfig object being used to render the button.