### PR TITLE
Exclude cancelled orders when checking if quote can be submitted in completeCheckoutSession

### DIFF
--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -336,7 +336,8 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
 
         $orderCollection = $this->orderCollectionFactory->create()
             ->addFieldToSelect('increment_id')
-            ->addFieldToFilter('quote_id', ['eq' => $quote->getId()]);
+            ->addFieldToFilter('quote_id', ['eq' => $quote->getId()])
+            ->addFieldToFilter('status', ['neq' => \Magento\Sales\Model\Order::STATE_CANCELED]);
 
         return ($orderCollection->count() == 0);
     }


### PR DESCRIPTION
In some payment gateways, the quote is restored on the session when a payment failure occurs. If this happens after the order has been created, the order is cancelled, and the quote is now active and associated with an existing order.

In CheckoutSessionManagement::canSubmitQuote(), we were previously returning false if the quote ID was associated with any existing order, regardless of status. This leads to the checkout session not being completed, and the order not being placed in Magento, but the checkout session still being updated and the user redirected to the amazonPayRedirectUrl, creating a transaction in Seller Central with no associated merchant reference ID. This fix addresses quotes that may have been restored from cancelled orders.