### PR TITLE
Check for charge permission ID on declined order before closing charge permission, add logging if not set

### DIFF
--- a/Model/AsyncManagement/Charge.php
+++ b/Model/AsyncManagement/Charge.php
@@ -210,7 +210,7 @@ class Charge extends AbstractOperation
             $this->closeLastTransaction($order);
             $this->amazonAdapter->closeChargePermission(
                 $order->getStoreId(),
-                $order->getPayment()->getAdditionalInformation()['charge_permission_id'],
+                array_key_exists('charge_permission_id', $order->getPayment()->getAdditionalInformation()) ? $order->getPayment()->getAdditionalInformation()['charge_permission_id'] : "",
                 'Canceled due to capture declined.',
                 true
             );


### PR DESCRIPTION
Additions to [PR #1126](https://github.com/amzn/amazon-payments-magento-2-plugin/pull/1126)