### PR TITLE
Retrieve fresh button config when store view changes

### DIFF
--- a/view/frontend/web/js/action/checkout-session-config-load.js
+++ b/view/frontend/web/js/action/checkout-session-config-load.js
@@ -22,10 +22,15 @@ define([
 ], function ($, _, remoteStorage, url, customerData) {
     'use strict';
 
+    const storageKey = 'amzn-checkout-session-config';
+    $('.switcher-option').on('click', function () {
+        $.localStorage.remove(storageKey);
+    });
+
     var localStorage = null;
     var getLocalStorage = function () {
         if (localStorage === null) {
-            localStorage = $.initNamespaceStorage('amzn-checkout-session-config').localStorage;
+            localStorage = $.initNamespaceStorage(storageKey).localStorage;
         }
         return localStorage;
     };


### PR DESCRIPTION
When the simplified button config caching was implemented to improve perceived rendering latency, changing the store view wasn't taken into account regarding refreshing the cached config. This could create a scenario where a customer has switched to a store that uses different AP credentials than the store where they started, and invalid config values are trying to be used to render the AP button.

This solution deletes the amzn-checkout-session-config entry from local storage when a new store view is selected.