### PR TITLE
ASD-849 - Prompt for billing address in APB flow when product type is…

### DIFF
--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -738,19 +738,6 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             }
 
             if ($amazonSession['productType'] == 'PayOnly') {
-                $addressData = $amazonSession['billingAddress'];
-
-                $addressData['state'] = $addressData['stateOrRegion'];
-                $addressData['phone'] = $addressData['phoneNumber'];
-
-                $address = array_combine(
-                    array_map('ucfirst', array_keys($addressData)),
-                    array_values($addressData)
-                );
-                $amazonAddress  = $this->amazonAddressFactory->create(['address' => $address]);
-
-                $customerAddress = $this->addressHelper->convertToMagentoEntity($amazonAddress);
-                $quote->getBillingAddress()->importCustomerAddressData($customerAddress);
                 if (empty($quote->getCustomerEmail())) {
                     $quote->setCustomerEmail($amazonSession['buyer']['email']);
                 }

--- a/view/frontend/web/js/amazon-button.js
+++ b/view/frontend/web/js/amazon-button.js
@@ -23,7 +23,9 @@ define([
     'Magento_Customer/js/customer-data',
     'Magento_Checkout/js/model/payment/additional-validators',
     'mage/storage',
-    'Magento_Checkout/js/model/error-processor'
+    'Magento_Checkout/js/model/error-processor',
+    'Magento_Checkout/js/action/set-billing-address',
+    'Magento_Ui/js/model/messageList',
 ], function (
         ko,
         $,
@@ -35,7 +37,9 @@ define([
         customerData,
         additionalValidators,
         storage,
-        errorProcessor
+        errorProcessor,
+        setBillingAddressAction,
+        globalMessageList
     ) {
     'use strict';
 
@@ -176,7 +180,7 @@ define([
 
                         if (self.buttonType === 'PayNow' && self._isPayOnly()) {
                             customerData.get('checkout-data').subscribe(function (checkoutData) {
-                                const opacity = checkoutData.selectedBillingAddress ? 1 : 0.5;
+                                const opacity = checkoutData.selectedBillingAddress ? 1 : 0.5;    
 
                                 const shadow = $('.amazon-checkout-button > div')[0].shadowRoot;
                                 $(shadow).find('.amazonpay-button-view1').css('opacity', opacity);
@@ -188,10 +192,12 @@ define([
         },
 
         _initCheckout: function (amazonPayButton) {
-            if (!customerData.get('checkout-data')().selectedBillingAddress
-                && this.buttonType === 'PayNow'
-                && this._isPayOnly()) {
-                return;
+            if (this.buttonType === 'PayNow' && this._isPayOnly()) {
+                if (!customerData.get('checkout-data')().selectedBillingAddress) {
+                    return;
+                } else {
+                    setBillingAddressAction(globalMessageList);
+                }
             }
 
             var payloadType = this.buttonType ?

--- a/view/frontend/web/js/amazon-button.js
+++ b/view/frontend/web/js/amazon-button.js
@@ -173,12 +173,27 @@ define([
 
                         $('.amazon-button-container .field-tooltip').fadeIn();
                         self.drawing = false;
+
+                        if (self.buttonType === 'PayNow' && self._isPayOnly()) {
+                            customerData.get('checkout-data').subscribe(function (checkoutData) {
+                                const opacity = checkoutData.selectedBillingAddress ? 1 : 0.5;
+
+                                const shadow = $('.amazon-checkout-button > div')[0].shadowRoot;
+                                $(shadow).find('.amazonpay-button-view1').css('opacity', opacity);
+                            });
+                        }
                     });
                 }, this);
             }
         },
 
         _initCheckout: function (amazonPayButton) {
+            if (!customerData.get('checkout-data')().selectedBillingAddress
+                && this.buttonType === 'PayNow'
+                && this._isPayOnly()) {
+                return;
+            }
+
             var payloadType = this.buttonType ?
                 'paynow' :
                 'checkout';

--- a/view/frontend/web/js/view/payment/method-renderer/amazon-payment-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/amazon-payment-method.js
@@ -44,7 +44,7 @@ define(
         return Component.extend({
             defaults: {
                 isAmazonCheckout: ko.observable(amazonStorage.isAmazonCheckout()),
-                isBillingAddressVisible: ko.observable(false),
+                isBillingAddressVisible: ko.observable(!quote.billingAddress()),
                 isIosc: ko.observable($('button.iosc-place-order-button').length > 0),
                 paymentDescriptor: ko.observable(''),
                 logo: 'Amazon_Pay/images/logo/Black-L.png',


### PR DESCRIPTION
… pay only

The section was removed in CheckoutSessionManagement.php because I don't believe there is a case anymore where the quote won't have an associated address by the time completeCheckoutSession is called in a PayOnly session. However, there still could be a case when the quote doesn't have email set in Express Checkout/PayOnly.