### PR TITLE
ASD-1139 adds check for existing cv2 public key before showing ake bu…

### DIFF
--- a/Block/Adminhtml/System/Config/AutoKeyExchangeAdmin.php
+++ b/Block/Adminhtml/System/Config/AutoKeyExchangeAdmin.php
@@ -82,6 +82,14 @@ class AutoKeyExchangeAdmin extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Already upgraded
+     */
+    public function hasCV2PublicKeyId()
+    {
+        return (bool)$this->keyUpgrade->getExistingPublicKeyId();
+    }
+
+    /**
      * Return Key Upgrade info
      */
     public function getKeyUpgradeConfig()

--- a/view/adminhtml/templates/system/config/autokeyexchange_admin.phtml
+++ b/view/adminhtml/templates/system/config/autokeyexchange_admin.phtml
@@ -20,7 +20,7 @@ $currency = $block->getCurrency();
 
 <br/>
 
-<?php if ($block->canUpgrade()): ?>
+<?php if ($block->canUpgrade() && !$block->hasCV2PublicKeyId()): ?>
     <div data-mage-init='{"Amazon_Pay/js/keyupgrade": <?= $block->escapeHtml($block->getKeyUpgradeConfig()) ?>}'
             id="amazon_keyupgrade">
         <div id="keyupgrade-hint">


### PR DESCRIPTION
…tton

In the case CV2 is successfully configured and legacy keys still exist in db, do not show the ake button.