### PR TITLE
Add undefined properties to ParadoxLabsSubscriptionManager (php8.2 compatibility)

### DIFF
--- a/Model/Subscription/ParadoxLabsSubscriptionManager.php
+++ b/Model/Subscription/ParadoxLabsSubscriptionManager.php
@@ -31,6 +31,26 @@ class ParadoxLabsSubscriptionManager implements SubscriptionManagerInterface
     private $searchCriteriaBuilder;
 
     /**
+     * @var \ParadoxLabs\Subscriptions\Model\Service\QuoteManager
+     */
+    public $quoteManager;
+
+    /**
+     * @var \ParadoxLabs\Subscriptions\Model\Service\ItemManager
+     */
+    public $itemManager;
+
+    /**
+     * @var \ParadoxLabs\Subscriptions\Model\SubscriptionRepository
+     */
+    public $subscriptionRepository;
+
+    /**
+     * @var \ParadoxLabs\Subscriptions\Model\Config
+     */
+    public $subscriptionConfig;
+
+    /**
      * ParadoxLabsSubscriptionManager constructor
      *
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder


### PR DESCRIPTION
Resolves amzn/amazon-payments-magento-2-plugin#1252

Fixes # .

#### Additional details about this PR