### PR TITLE
ASD-1292 Move amazon checkout button to different parent to avoid con…

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -51,6 +51,8 @@
                                                     <item name="children" xsi:type="array">
                                                         <item name="customer-email" xsi:type="array">
                                                             <item name="children" xsi:type="array">
+                                                        <item name="before-login-form" xsi:type="array">
+                                                            <item name="children" xsi:type="array">
                                                                 <item name="amazon-pay-button-region" xsi:type="array">
                                                                     <item name="component" xsi:type="string">uiComponent</item>
                                                                     <item name="displayArea" xsi:type="string">amazon-button-region</item>
@@ -82,11 +84,6 @@
                                                                         </item>
                                                                     </item>
                                                                 </item>
-                                                            </item>
-                                                        </item>
-
-                                                        <item name="before-form" xsi:type="array">
-                                                            <item name="children" xsi:type="array">
                                                                 <item name="amazon-pay-address" xsi:type="array">
                                                                     <item name="component" xsi:type="string">Amazon_Pay/js/view/checkout-address</item>
                                                                     <item name="sortOrder" xsi:type="string">0</item>
@@ -95,6 +92,8 @@
                                                                         <item name="isPayOnly" xsi:type="helper" helper="Amazon\Pay\Helper\Data::isPayOnly"/>
                                                                     </item>
                                                                 </item>
+                                                            </item>
+                                                        </item>
                                                             </item>
                                                         </item>
                                                     </item>


### PR DESCRIPTION
Move amazon checkout button to different parent to avoid conflict with paypal

Fixes [ASD-1292](https://bearideas.jira.com/jira/servicedesk/projects/ASD/queues/custom/147/ASD-1292) .

#### Additional details about this PR
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/de9a5939-803c-4252-a384-66741f84123d" />


[ASD-1292]: https://bearideas.jira.com/browse/ASD-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ