### PR TITLE
ASD-1314 Fix order cancelation if session is open

### DIFF
--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -771,6 +771,20 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
 
         try {
             $order = $this->orderRepository->get($orderId);
+
+            // Do not proceed with payment capture if the order is already cancelled.
+            // This prevents charging the customer when the Magento order will not be fulfilled.
+            if ($order->getState() === \Magento\Sales\Model\Order::STATE_CANCELED) {
+                $this->logger->error(
+                    'completeCheckoutSession: order ' . $order->getIncrementId() . ' is already cancelled'
+                    . ' (amazonSessionId: ' . $amazonSessionId . '). Aborting to prevent capture on cancelled order.'
+                );
+                return $this->handleCompleteCheckoutSessionError(
+                    self::GENERIC_COMPLETE_CHECKOUT_ERROR_MESSAGE,
+                    'Order ' . $order->getIncrementId() . ' is already cancelled, will not complete checkout session ' . $amazonSessionId
+                );
+            }
+
             $quote = $this->getQuote($order);
 
             // @TODO: associate token with payment?
@@ -1253,6 +1267,21 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
                 $order->getStoreId(),
                 $amazonSessionId
             );
+
+            // Do NOT cancel the order If the session is still Open
+            if (($session['statusDetails']['state'] ?? null) === 'Open') {
+                $this->logger->info(
+                    'completeAmazonCheckoutSession returned HTTP ' . $completeCheckoutStatus
+                    . ' but session ' . $amazonSessionId . ' is still Open'
+                    . ' (possible MFA in progress). Order ' . $order->getIncrementId() . ' will not be cancelled.'
+                );
+                $this->setPending($order->getPayment());
+                return $this->handleCompleteCheckoutSessionError(
+                    self::GENERIC_COMPLETE_CHECKOUT_ERROR_MESSAGE,
+                    'completeCheckoutSession returned ' . $completeCheckoutStatus
+                    . ' but session is still Open: ' . ($amazonCompleteCheckoutResult['message'] ?? '')
+                );
+            }
 
             $cancelledMessage = $this->getCanceledMessage($session);
 


### PR DESCRIPTION
Fixes [1314](https://bearideas.jira.com/jira/servicedesk/projects/ASD/queues/custom/147/ASD-1314) .

#### Additional details about this PR
Reproducing two issues:
- Order with an open session gets incorrectly canceled
- Canceled order's transaction can still be captured

REPRODUCE:

Set sleep(90) for mock MFA:
/home/dima/bear/amazon/m248p3/amazon-pay-git/Controller/Checkout/CompleteSession.php



```
public function execute()
    {
        sleep(90);
        $scope = $this->storeManager->getStore()->getId();
        try {
```
To get incomplete transactions quicker I set MIN_ORDER_AGE_MINUTES to 0

/home/dima/bear/amazon/m248p3/amazon-pay-git/Helper/Transaction.php



    protected const MIN_ORDER_AGE_MINUTES = 0;
To mock 422 status I added response:
/home/dima/bear/amazon/m248p3/amazon-pay-git/Model/Adapter/AmazonPayAdapter.php



    public function completeCheckoutSession($storeId, $sessionId, $amount, $currencyCode)
    {
        if (file_exists('/tmp/amzpay_simulate_422')) {
           return [
                'status' => '422',
                'reasonCode' => 'InvalidCheckoutSessionStatus',
                'message' => 'CheckoutSession is in a state where the operation is not allowed',
            ];
       }
 

Steps to reproduce:

touch /tmp/amzpay_simulate_422 

create order

During the sleep (MFA mock), check if there are incomplete transactions:




```
php -r '                    
  require "app/bootstrap.php";
  $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
  $om = $bootstrap->getObjectManager();
  $state = $om->get(\Magento\Framework\App\State::class);
  try { $state->setAreaCode("crontab"); } catch (\Exception $e) {}
  print_r($om->get(\Amazon\Pay\Helper\Transaction::class)->getIncomplete());
  '
```
Check if order is created

run CleanUpIncompleteSessions



```
php -r '                                                                                                                                                                   
    require "app/bootstrap.php";                                                                                                                                             
    $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);                                                                                                     
    $om = $bootstrap->getObjectManager();                                                                                                                                    
    $state = $om->get(\Magento\Framework\App\State::class);                                                                                                                  
    try { $state->setAreaCode("crontab"); } catch (\Exception $e) {}                                                                                                         
    $om->get(\Amazon\Pay\Cron\CleanUpIncompleteSessions::class)->execute();                                                                                                  
  '
```
Check that order is canceled.

During the sleep window(MFA mock), remove the 422 flag:



rm /tmp/amzpay_simulate_422  
After the sleep finishes, the order gets processed and the transaction is captured

Test Canceled order can't be captured:

 remove flag 422 simulate

Cancel order during sleep time (MFA mock)



```
php -r '                                                                                                                                                                   
  require "app/bootstrap.php";                                                                                                                                               
  $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);                                                                                                       
  $om = $bootstrap->getObjectManager();                                                                                                                                      
  $state = $om->get(\Magento\Framework\App\State::class);                                                                                                                    
  try { $state->setAreaCode("adminhtml"); } catch (\Exception $e) {}                                                                                                         
  $orderRepo = $om->get(\Magento\Sales\Api\OrderRepositoryInterface::class);                                                                                                 
  $order = $orderRepo->get(882);                                                                                                                                   
  $order->setState(\Magento\Sales\Model\Order::STATE_CANCELED);                                                                                                              
  $order->setStatus(\Magento\Sales\Model\Order::STATE_CANCELED);
  $order->addStatusHistoryComment("Manually cancelled for bug reproduction");                                                                                                
  $orderRepo->save($order);                                                                                                                                                  
  echo "Order " . $order->getIncrementId() . " cancelled\n";'
```
Confirm the order remains canceled and no capture transaction is created