### PR TITLE
ASD-1311 Convert nulls to empty strings before preg_replace

### DIFF
--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -241,6 +241,12 @@ class Address
      */
     protected function fuzzyCompare($a, $b)
     {
-        return strtolower(preg_replace("#[[:punct:]]#", "", $a)) == strtolower(preg_replace("#[[:punct:]]#", "", $b));
+        $a = ($a === null) ? '' : (string)$a;
+        $b = ($b === null) ? '' : (string)$b;
+
+        $a = strtolower(preg_replace("#[[:punct:]]#", "", $a));
+        $b = strtolower(preg_replace("#[[:punct:]]#", "", $b));
+
+        return $a === $b;
     }
 }


### PR DESCRIPTION
Fixes [1292](https://github.com/amzn/amazon-payments-magento-2-plugin/issues/1292) 