### PR TITLE
ASD-1291 order canceled

### DIFF
--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -773,6 +773,18 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             $order = $this->orderRepository->get($orderId);
             $quote = $this->getQuote($order);
 
+            // Idempotency guard - prevent processing an order if it has already been processed;
+            // charge_permission_id is persisted only after a successful handlePayment;
+            // its presence means this completeSession call is a duplicate.
+            if ($order->getPayment()
+                && $order->getPayment()->getAdditionalInformation('charge_permission_id')) {
+                return [
+                    'success' => true,
+                    'order_id' => $order->getId(),
+                    'increment_id' => $order->getIncrementId(),
+                ];
+            }
+
             // @TODO: associate token with payment?
             $result['order_id'] = $orderId;
             $result['increment_id'] = $order->getIncrementId();

--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -1298,6 +1298,15 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             $amazonCompleteCheckoutResult = $amazonCheckoutResult['amazonCompleteCheckoutResult'];
             $payment = $order->getPayment();
             $chargeId = $amazonCompleteCheckoutResult['chargeId'];
+
+            // Persist charge_permission_id immediately so concurrent duplicate
+            // completeCheckoutSession calls short-circuit via the idempotency guard.
+            $payment->setAdditionalInformation(
+                'charge_permission_id',
+                $amazonCompleteCheckoutResult['chargePermissionId']
+            );
+            $this->paymentRepository->save($payment);
+
             $transaction = $this->getTransaction($amazonCompleteCheckoutResult['checkoutSessionId']);
             $completeCheckoutStatus = $amazonCompleteCheckoutResult['status'] ?? '404';
 
@@ -1352,12 +1361,6 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
                     }
                     break;
             }
-
-            // relies on updateTransactionId to save the $payment
-            $payment->setAdditionalInformation(
-                'charge_permission_id',
-                $amazonCompleteCheckoutResult['chargePermissionId']
-            );
 
             $this->updateTransactionId($chargeId, $payment, $transaction);
             $this->updateVaultToken(


### PR DESCRIPTION
Fixes [ASD-1291](https://bearideas.jira.com/jira/servicedesk/projects/ASD/queues/custom/147/ASD-1291) .



When completeCheckoutSession is called more than once for the same Amazon checkout session, the second call re-enters handlePayment with stale state. The catch then calls cancelOrder(), so the customer ends up charged on Amazon while the Magento order is in Canceled.

Duplicate calls can come from the controller, the graphql resolver, the cleanup cron, or merchant-side custom code.

Fix:
Idempotency guard at the top of completeCheckoutSession(): if the order's payment already has charge_permission_id set, return success without re-entering handlePayment. charge_permission_id is now also persisted at the top
of handlePayment (instead of after the switch) so concurrent in-flight duplicates skip too.

Locally reproduced with a temporary observer on sales_order_invoice_save_after that fires in-process recursive completeCheckoutSession call. Without the fix the order ends up Canceled / Total Paid $10. With the fix the duplicates skip and the order stays Processing with one paid invoice. 

[ASD-1291]: https://bearideas.jira.com/browse/ASD-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ