### PR TITLE
Suppress order confirmation email on order and invoice cancellation

### DIFF
--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -65,6 +65,16 @@ class SendEmail
                     !empty($subject->getStatusHistories()) &&
                     !$subject->getEmailSent()
                     ) {
+                    foreach ($subject->getAllItems() as $item) {
+                        if ($item->getQtyCanceled() > 0) {
+                            return $result;
+                        }
+                    }
+                    if ($subject->hasInvoices() &&
+                        !((float)$subject->getTotalPaid() > 0) &&
+                        !((float)$subject->getTotalInvoiced() > 0)) {
+                        return $result;
+                    }
                     $subject->setCanSendNewEmailFlag(true);
                     $this->orderSender->send($subject);
                 }

--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -71,8 +71,9 @@ class SendEmail
                         }
                     }
                     if ($subject->hasInvoices() &&
-                        !((float)$subject->getTotalPaid() > 0) &&
-                        !((float)$subject->getTotalInvoiced() > 0)) {
+                        (float)$subject->getTotalPaid() <= 0 &&
+                        (float)$subject->getTotalInvoiced() <= 0
+                        ) {
                         return $result;
                     }
                     $subject->setCanSendNewEmailFlag(true);


### PR DESCRIPTION
### Summary

Suppress the order confirmation email when an Amazon Pay order (or its pending invoice) is cancelled. This is the same fix as amzn/amazon-payments-magento-2-plugin#1298 (which addresses amzn issue #1259), retargeted to `release/5.18.6` at @darkdragon-001 / Dima's request — see https://github.com/amzn/amazon-payments-magento-2-plugin/pull/1298#issuecomment-4781828398.

### Problem

`SendEmail::afterSetState()` sends the confirmation email whenever the order transitions to `STATE_PROCESSING` with status histories and no email yet sent. Two cancellation paths hit that transient PROCESSING state and wrongly fire the email:

1. **Order cancellation** — `Order::registerCancellation()` moves through PROCESSING.
2. **Pending-invoice cancellation** — `Invoice::cancel()` on an unpaid invoice also passes through PROCESSING.

### Fix

- Bail out if any item has `qty_canceled > 0` (covers the order-cancel case).
- Bail out when the order `hasInvoices()` but neither `total_paid` nor `total_invoiced` is positive (covers the invoice-cancel case).

The `total_invoiced` clause is important: for `authorize_capture` with async capture, the invoice is registered at placement (so `total_invoiced == grand_total`) but is paid *after* the PROCESSING transition (`total_paid == 0` at the hook). Checking only `total_paid` suppressed *all* legitimate Amazon confirmation emails — the `total_invoiced` guard distinguishes a legit order (invoice present) from a cancelled one (`Invoice::cancel()` decrements `total_invoiced` to 0 before the transient setState).
