### PR TITLE
Asd 1326

### DIFF
--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -161,6 +161,12 @@ class CleanUpIncompleteSessions
         $order = $this->loadOrder($orderId);
 
         if ($order) {
+            if ($this->isOrderPaidOrCaptured($order)) {
+                $this->logger->info(
+                    self::LOG_PREFIX . 'Skip cancellation for already paid/captured order: ' . $orderId
+                );
+                return;
+            }
             $this->checkoutSessionManagement->cancelOrder($order, null, $reasonMessage);
         } else {
             $this->logger->error(self::LOG_PREFIX . 'Order not found for ID: ' . $orderId);
@@ -181,5 +187,55 @@ class CleanUpIncompleteSessions
             $this->logger->error(self::LOG_PREFIX . 'Error loading order: ' . $e->getMessage());
             return null;
         }
+    }
+
+    /**
+     * Prevent cancellation if payment is already completed.
+     *
+     * @param OrderInterface $order
+     * @return bool
+     */
+    private function isOrderPaidOrCaptured(OrderInterface $order)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        $chargeId = $this->extractChargeIdFromOrder($order);
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonPayAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->logger->error(self::LOG_PREFIX . 'Unable to verify charge state before cancel. chargeId: '
+                . $chargeId . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve charge ID from payment transaction data where possible.
+     *
+     * @param OrderInterface $order
+     * @return string|null
+     */
+    private function extractChargeIdFromOrder(OrderInterface $order)
+    {
+        $transactionId = (string)$order->getPayment()->getLastTransId();
+        if ($transactionId === '') {
+            return null;
+        }
+
+        foreach (['-capture', '-void'] as $suffix) {
+            if (substr($transactionId, -strlen($suffix)) === $suffix) {
+                return substr($transactionId, 0, -strlen($suffix));
+            }
+        }
+
+        return $transactionId;
     }
 }

--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -20,6 +20,7 @@ use Amazon\Pay\Helper\Transaction as TransactionHelper;
 use Amazon\Pay\Logger\Logger;
 use Amazon\Pay\Model\Adapter\AmazonPayAdapter;
 use Amazon\Pay\Model\CheckoutSessionManagement;
+use Amazon\Pay\Model\Payment\PaidOrderGuard;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Amazon\Pay\Model\AsyncManagement\Charge as AsyncCharge;
@@ -63,12 +64,18 @@ class CleanUpIncompleteSessions
     protected $asyncCharge;
 
     /**
+     * @var PaidOrderGuard
+     */
+    protected $paidOrderGuard;
+
+    /**
      * @param TransactionHelper $transactionHelper
      * @param Logger $logger
      * @param AmazonPayAdapter $amazonPayAdapter
      * @param CheckoutSessionManagement $checkoutSessionManagement
      * @param OrderRepositoryInterface $orderRepository
      * @param AsyncCharge $asyncCharge
+     * @param PaidOrderGuard $paidOrderGuard
      */
     public function __construct(
         TransactionHelper $transactionHelper,
@@ -76,7 +83,8 @@ class CleanUpIncompleteSessions
         AmazonPayAdapter $amazonPayAdapter,
         CheckoutSessionManagement $checkoutSessionManagement,
         OrderRepositoryInterface $orderRepository,
-        AsyncCharge $asyncCharge
+        AsyncCharge $asyncCharge,
+        PaidOrderGuard $paidOrderGuard
     ) {
         $this->transactionHelper = $transactionHelper;
         $this->logger = $logger;
@@ -84,6 +92,7 @@ class CleanUpIncompleteSessions
         $this->checkoutSessionManagement = $checkoutSessionManagement;
         $this->orderRepository = $orderRepository;
         $this->asyncCharge = $asyncCharge;
+        $this->paidOrderGuard = $paidOrderGuard;
     }
 
     /**
@@ -161,7 +170,7 @@ class CleanUpIncompleteSessions
         $order = $this->loadOrder($orderId);
 
         if ($order) {
-            if ($this->isOrderPaidOrCaptured($order)) {
+            if ($this->paidOrderGuard->isOrderPaidOrCaptured($order)) {
                 $this->logger->info(
                     self::LOG_PREFIX . 'Skip cancellation for already paid/captured order: ' . $orderId
                 );
@@ -189,53 +198,4 @@ class CleanUpIncompleteSessions
         }
     }
 
-    /**
-     * Prevent cancellation if payment is already completed.
-     *
-     * @param OrderInterface $order
-     * @return bool
-     */
-    private function isOrderPaidOrCaptured(OrderInterface $order)
-    {
-        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
-            return true;
-        }
-
-        $chargeId = $this->extractChargeIdFromOrder($order);
-        if (!$chargeId) {
-            return false;
-        }
-
-        try {
-            $charge = $this->amazonPayAdapter->getCharge($order->getStoreId(), $chargeId);
-            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
-        } catch (\Exception $e) {
-            $this->logger->error(self::LOG_PREFIX . 'Unable to verify charge state before cancel. chargeId: '
-                . $chargeId . ' Error: ' . $e->getMessage());
-        }
-
-        return false;
-    }
-
-    /**
-     * Resolve charge ID from payment transaction data where possible.
-     *
-     * @param OrderInterface $order
-     * @return string|null
-     */
-    private function extractChargeIdFromOrder(OrderInterface $order)
-    {
-        $transactionId = (string)$order->getPayment()->getLastTransId();
-        if ($transactionId === '') {
-            return null;
-        }
-
-        foreach (['-capture', '-void'] as $suffix) {
-            if (substr($transactionId, -strlen($suffix)) === $suffix) {
-                return substr($transactionId, 0, -strlen($suffix));
-            }
-        }
-
-        return $transactionId;
-    }
 }

--- a/Helper/Transaction.php
+++ b/Helper/Transaction.php
@@ -110,8 +110,9 @@ class Transaction
             )
             // No async record pending
             ->where('apa.pending_action IS NULL')
-            // Order awaiting payment
-            ->where("so.status = ?", Order::STATE_PAYMENT_REVIEW)
+            // Order awaiting payment; match on state so orders with custom
+            // statuses assigned by third-party order management are not missed
+            ->where("so.state = ?", Order::STATE_PAYMENT_REVIEW)
             // A transaction is not complete
             ->where('spt.is_closed <> ?', 1)
             // Delay processing new orders

--- a/Model/AsyncManagement/Charge.php
+++ b/Model/AsyncManagement/Charge.php
@@ -101,7 +101,7 @@ class Charge extends AbstractOperation
         \Amazon\Pay\Model\AmazonConfig $amazonConfig,
         \Magento\Framework\Event\ManagerInterface $eventManager
     ) {
-        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder);
+        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder, $asyncLogger);
         $this->amazonAdapter = $amazonAdapter;
         $this->asyncLogger = $asyncLogger;
         $this->invoiceRepository = $invoiceRepository;

--- a/Model/AsyncManagement/Charge.php
+++ b/Model/AsyncManagement/Charge.php
@@ -209,6 +209,14 @@ class Charge extends AbstractOperation
      */
     public function decline($order, $chargeId, $detail)
     {
+        if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+            $this->asyncLogger->warning(
+                'Skip decline cancellation for already paid/captured Order #' . $order->getIncrementId()
+                    . ' chargeId: ' . $chargeId
+            );
+            return;
+        }
+
         $invoice = $this->loadInvoice($chargeId, $order);
         if ($invoice) {
             $invoice->cancel();
@@ -259,6 +267,13 @@ class Charge extends AbstractOperation
      */
     public function cancel($order, $detail)
     {
+        if ($this->isOrderPaidOrCaptured($order)) {
+            $this->asyncLogger->warning(
+                'Skip async cancel for already paid/captured Order #' . $order->getIncrementId()
+            );
+            return;
+        }
+
         if (!$order->isCanceled()) {
             $order->addStatusHistoryComment($detail['reasonCode'] . ' - ' . $detail['reasonDescription']);
             $order->cancel();
@@ -367,5 +382,56 @@ class Charge extends AbstractOperation
             $order->addStatusHistoryComment($errorMessage);
             $order->save();
         }
+    }
+
+    /**
+     * Prevent cancellation if payment is already completed.
+     *
+     * @param OrderInterface $order
+     * @param string|null $chargeId
+     * @return bool
+     */
+    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        $chargeId = $chargeId ?: $this->extractChargeIdFromOrder($order);
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->asyncLogger->error('Unable to verify charge state before cancel. chargeId: ' . $chargeId
+                . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve charge ID from payment transaction data where possible.
+     *
+     * @param OrderInterface $order
+     * @return string|null
+     */
+    private function extractChargeIdFromOrder(OrderInterface $order)
+    {
+        $transactionId = (string)$order->getPayment()->getLastTransId();
+        if ($transactionId === '') {
+            return null;
+        }
+
+        foreach (['-capture', '-void'] as $suffix) {
+            if (substr($transactionId, -strlen($suffix)) === $suffix) {
+                return substr($transactionId, 0, -strlen($suffix));
+            }
+        }
+
+        return $transactionId;
     }
 }

--- a/Model/AsyncManagement/Charge.php
+++ b/Model/AsyncManagement/Charge.php
@@ -72,6 +72,11 @@ class Charge extends AbstractOperation
     private $eventManager;
 
     /**
+     * @var \Amazon\Pay\Model\Payment\PaidOrderGuard
+     */
+    private $paidOrderGuard;
+
+    /**
      * Charge constructor.
      *
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
@@ -86,6 +91,7 @@ class Charge extends AbstractOperation
      * @param \Magento\Backend\Model\UrlInterface $urlBuilder
      * @param \Amazon\Pay\Model\AmazonConfig $amazonConfig
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
+     * @param \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
      */
     public function __construct(
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
@@ -99,7 +105,8 @@ class Charge extends AbstractOperation
         \Magento\Framework\Notification\NotifierInterface $notifier,
         \Magento\Backend\Model\UrlInterface $urlBuilder,
         \Amazon\Pay\Model\AmazonConfig $amazonConfig,
-        \Magento\Framework\Event\ManagerInterface $eventManager
+        \Magento\Framework\Event\ManagerInterface $eventManager,
+        \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
     ) {
         parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder, $asyncLogger);
         $this->amazonAdapter = $amazonAdapter;
@@ -111,6 +118,7 @@ class Charge extends AbstractOperation
         $this->urlBuilder = $urlBuilder;
         $this->amazonConfig = $amazonConfig;
         $this->eventManager = $eventManager;
+        $this->paidOrderGuard = $paidOrderGuard;
     }
 
     /**
@@ -209,7 +217,7 @@ class Charge extends AbstractOperation
      */
     public function decline($order, $chargeId, $detail)
     {
-        if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+        if ($this->paidOrderGuard->isOrderPaidOrCaptured($order, $chargeId)) {
             $this->asyncLogger->warning(
                 'Skip decline cancellation for already paid/captured Order #' . $order->getIncrementId()
                     . ' chargeId: ' . $chargeId
@@ -267,7 +275,7 @@ class Charge extends AbstractOperation
      */
     public function cancel($order, $detail)
     {
-        if ($this->isOrderPaidOrCaptured($order)) {
+        if ($this->paidOrderGuard->isOrderPaidOrCaptured($order)) {
             $this->asyncLogger->warning(
                 'Skip async cancel for already paid/captured Order #' . $order->getIncrementId()
             );
@@ -384,54 +392,4 @@ class Charge extends AbstractOperation
         }
     }
 
-    /**
-     * Prevent cancellation if payment is already completed.
-     *
-     * @param OrderInterface $order
-     * @param string|null $chargeId
-     * @return bool
-     */
-    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
-    {
-        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
-            return true;
-        }
-
-        $chargeId = $chargeId ?: $this->extractChargeIdFromOrder($order);
-        if (!$chargeId) {
-            return false;
-        }
-
-        try {
-            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
-            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
-        } catch (\Exception $e) {
-            $this->asyncLogger->error('Unable to verify charge state before cancel. chargeId: ' . $chargeId
-                . ' Error: ' . $e->getMessage());
-        }
-
-        return false;
-    }
-
-    /**
-     * Resolve charge ID from payment transaction data where possible.
-     *
-     * @param OrderInterface $order
-     * @return string|null
-     */
-    private function extractChargeIdFromOrder(OrderInterface $order)
-    {
-        $transactionId = (string)$order->getPayment()->getLastTransId();
-        if ($transactionId === '') {
-            return null;
-        }
-
-        foreach (['-capture', '-void'] as $suffix) {
-            if (substr($transactionId, -strlen($suffix)) === $suffix) {
-                return substr($transactionId, 0, -strlen($suffix));
-            }
-        }
-
-        return $transactionId;
-    }
 }

--- a/Model/AsyncManagement/Refund.php
+++ b/Model/AsyncManagement/Refund.php
@@ -74,7 +74,7 @@ class Refund extends AbstractOperation
         \Magento\Framework\Notification\NotifierInterface $notifier,
         \Magento\Backend\Model\UrlInterface $urlBuilder
     ) {
-        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder);
+        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder, $asyncLogger);
         $this->amazonAdapter = $amazonAdapter;
         $this->asyncLogger = $asyncLogger;
         $this->invoiceService = $invoiceService;

--- a/Model/AsyncUpdater.php
+++ b/Model/AsyncUpdater.php
@@ -105,6 +105,10 @@ class AsyncUpdater
             $this->logger->error($e);
             $this->asyncLogger->error($e);
             $async->getResource()->rollBack();
+        } catch (\Throwable $e) {
+            $this->logger->error('An error occurred during the async transaction process: ' . $e->getMessage());
+            $this->asyncLogger->error($e);
+            $async->getResource()->rollBack();
         }
     }
 

--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -792,11 +792,20 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
 
         } catch (\Exception $e) {
             if (isset($order)) {
-                $this->closeChargePermission($amazonSessionId, $order, $e);
-                $session = $this->getAmazonSession($amazonSessionId);
-                $cancelledMessage = $this->getCanceledMessage($session);
-                $this->cancelOrder($order, $quote, $cancelledMessage);
-                $this->magentoCheckoutSession->restoreQuote();
+                if ($this->isOrderPaidOrCaptured($order)) {
+                    $this->logger->error(
+                        'Checkout completion failed after payment succeeded; order not canceled. '
+                        . 'amazonSessionId: ' . $amazonSessionId
+                        . ' orderId: ' . $order->getEntityId()
+                        . ' Error: ' . $e->getMessage()
+                    );
+                } else {
+                    $this->closeChargePermission($amazonSessionId, $order, $e);
+                    $session = $this->getAmazonSession($amazonSessionId);
+                    $cancelledMessage = $this->getCanceledMessage($session);
+                    $this->cancelOrder($order, $quote, $cancelledMessage);
+                    $this->magentoCheckoutSession->restoreQuote();
+                }
             }
 
             throw $e;
@@ -1296,6 +1305,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
      */
     private function handlePayment($amazonSessionId, $amazonCheckoutResult, $order, $quote)
     {
+        $chargeId = null;
         try {
             // $amazonCheckoutResult holds success flag and actual result from api call
             $amazonCompleteCheckoutResult = $amazonCheckoutResult['amazonCompleteCheckoutResult'];
@@ -1321,26 +1331,27 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             }
             $amazonCharge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
 
-            // @TODO: for recurring, the order incremenet ID needs to be updated on the charge
-            //Send merchantReferenceId to Amazon
-            $this->amazonAdapter->updateChargePermission(
-                $order->getStoreId(),
-                $amazonCharge['chargePermissionId'],
-                ['merchantReferenceId' => $order->getIncrementId()]
-            );
-
             $chargeState = $amazonCharge['statusDetails']['state'];
 
             switch ($chargeState) {
                 case 'AuthorizationInitiated':
+                case 'CaptureInitiated':
                     $payment->setIsTransactionClosed(false);
                     $this->setPending($payment);
                     $transaction->setIsClosed(false);
                     $this->asyncManagement->queuePendingAuthorization($chargeId);
                     break;
                 case 'Authorized':
-                    $this->setProcessing($payment);
-                    if ($this->amazonConfig->getAuthorizationMode() == AuthorizationMode::SYNC_THEN_ASYNC) {
+                    if ($this->amazonConfig->getPaymentAction() == PaymentAction::AUTHORIZE_AND_CAPTURE) {
+                        $payment->setIsTransactionClosed(false);
+                        $this->setPending($payment);
+                        $transaction->setIsClosed(false);
+                        $this->asyncManagement->queuePendingAuthorization($chargeId);
+                    } else {
+                        $this->setProcessing($payment);
+                    }
+                    if ($this->amazonConfig->getPaymentAction() == PaymentAction::AUTHORIZE &&
+                        $this->amazonConfig->getAuthorizationMode() == AuthorizationMode::SYNC_THEN_ASYNC) {
                         $this->addCaptureComment($payment, $amazonCharge['chargePermissionId']);
                     }
                     break;
@@ -1363,14 +1374,47 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             );
 
             $this->updateTransactionId($chargeId, $payment, $transaction);
-            $this->updateVaultToken(
-                $amazonSessionId,
-                $amazonCompleteCheckoutResult['chargePermissionId'],
-                $quote,
-                $order
-            );
+
+            // Best-effort update only; should never fail checkout after payment succeeds.
+            try {
+                $this->amazonAdapter->updateChargePermission(
+                    $order->getStoreId(),
+                    $amazonCharge['chargePermissionId'],
+                    ['merchantReferenceId' => $order->getIncrementId()]
+                );
+            } catch (\Exception $e) {
+                $this->logger->error('Unable to update charge permission metadata. chargeId: ' . $chargeId
+                    . ' Error: ' . $e->getMessage());
+            }
+
+            // Best-effort token maintenance only; payment result should not be reversed if this fails.
+            try {
+                $this->updateVaultToken(
+                    $amazonSessionId,
+                    $amazonCompleteCheckoutResult['chargePermissionId'],
+                    $quote,
+                    $order
+                );
+            } catch (\Exception $e) {
+                $this->logger->error('Unable to update vault token. chargeId: ' . $chargeId
+                    . ' Error: ' . $e->getMessage());
+            }
             return ['success'=>true];
         } catch (\Exception $e) {
+            if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+                $this->logger->error(
+                    'Checkout completion encountered a post-payment error; order not canceled. '
+                    . 'amazonSessionId: ' . $amazonSessionId
+                    . ' chargeId: ' . ($chargeId ?: 'n/a')
+                    . ' orderId: ' . $order->getEntityId()
+                    . ' Error: ' . $e->getMessage()
+                );
+                return [
+                    'success' => true,
+                    'order_id' => $order->getEntityId()
+                ];
+            }
+
             $this->closeChargePermission($amazonSessionId, $order, $e);
 
             $session = $this->amazonAdapter->getCheckoutSession(
@@ -1390,6 +1434,34 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
                 $logEntryDetails
             );
         }
+    }
+
+    /**
+     * Check if payment succeeded enough to prevent canceling the order on follow-up errors.
+     *
+     * @param OrderInterface $order
+     * @param string|null $chargeId
+     * @return bool
+     */
+    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->logger->error('Unable to verify charge state before order cancel. chargeId: ' . $chargeId
+                . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
     }
 
     /**

--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -236,6 +236,11 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
     private $updateCouponUsages;
 
     /**
+     * @var \Amazon\Pay\Model\Payment\PaidOrderGuard
+     */
+    private $paidOrderGuard;
+
+    /**
      * CheckoutSessionManagement constructor.
      *
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
@@ -273,6 +278,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
      * @param Session $session
      * @param Translate $translationRenderer
      * @param UpdateCouponUsages $updateCouponUsages
+     * @param \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
      */
     public function __construct(
         \Magento\Store\Model\StoreManagerInterface $storeManager,
@@ -309,7 +315,8 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
         \Amazon\Pay\Logger\Logger $logger,
         Session $session,
         Translate $translationRenderer,
-        UpdateCouponUsages $updateCouponUsages
+        UpdateCouponUsages $updateCouponUsages,
+        \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
     ) {
         $this->storeManager = $storeManager;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
@@ -346,6 +353,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
         $this->session = $session;
         $this->translationRenderer = $translationRenderer;
         $this->updateCouponUsages = $updateCouponUsages;
+        $this->paidOrderGuard = $paidOrderGuard;
     }
 
     /**
@@ -792,7 +800,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
 
         } catch (\Exception $e) {
             if (isset($order)) {
-                if ($this->isOrderPaidOrCaptured($order)) {
+                if ($this->paidOrderGuard->isOrderPaidOrCaptured($order, null, false)) {
                     $this->logger->error(
                         'Checkout completion failed after payment succeeded; order not canceled. '
                         . 'amazonSessionId: ' . $amazonSessionId
@@ -1401,7 +1409,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             }
             return ['success'=>true];
         } catch (\Exception $e) {
-            if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+            if ($this->paidOrderGuard->isOrderPaidOrCaptured($order, $chargeId, false)) {
                 $this->logger->error(
                     'Checkout completion encountered a post-payment error; order not canceled. '
                     . 'amazonSessionId: ' . $amazonSessionId
@@ -1434,34 +1442,6 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
                 $logEntryDetails
             );
         }
-    }
-
-    /**
-     * Check if payment succeeded enough to prevent canceling the order on follow-up errors.
-     *
-     * @param OrderInterface $order
-     * @param string|null $chargeId
-     * @return bool
-     */
-    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
-    {
-        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
-            return true;
-        }
-
-        if (!$chargeId) {
-            return false;
-        }
-
-        try {
-            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
-            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
-        } catch (\Exception $e) {
-            $this->logger->error('Unable to verify charge state before order cancel. chargeId: ' . $chargeId
-                . ' Error: ' . $e->getMessage());
-        }
-
-        return false;
     }
 
     /**

--- a/Model/Payment/PaidOrderGuard.php
+++ b/Model/Payment/PaidOrderGuard.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright © Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon\Pay\Model\Payment;
+
+use Amazon\Pay\Logger\Logger;
+use Amazon\Pay\Model\Adapter\AmazonPayAdapter;
+use Magento\Sales\Api\Data\OrderInterface;
+
+/**
+ * Guards order cancellation paths against voiding orders whose payment already succeeded.
+ */
+class PaidOrderGuard
+{
+    /**
+     * @var AmazonPayAdapter
+     */
+    private $amazonAdapter;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @param AmazonPayAdapter $amazonAdapter
+     * @param Logger $logger
+     */
+    public function __construct(
+        AmazonPayAdapter $amazonAdapter,
+        Logger $logger
+    ) {
+        $this->amazonAdapter = $amazonAdapter;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Check if payment succeeded enough to prevent canceling the order on follow-up errors.
+     *
+     * Checks order totals first; falls back to a live Amazon charge state lookup. When no
+     * charge ID is given, $resolveChargeIdFromOrder controls whether one is derived from the
+     * payment's last transaction ID (checkout-flow callers pass false: their last transaction
+     * may be a checkout-session ID, not a charge).
+     *
+     * @param OrderInterface $order
+     * @param string|null $chargeId
+     * @param bool $resolveChargeIdFromOrder
+     * @return bool
+     */
+    public function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null, $resolveChargeIdFromOrder = true)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        if (!$chargeId && $resolveChargeIdFromOrder) {
+            $chargeId = $this->extractChargeIdFromOrder($order);
+        }
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->logger->error('Unable to verify charge state before cancel. chargeId: ' . $chargeId
+                . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve charge ID from payment transaction data where possible.
+     *
+     * @param OrderInterface $order
+     * @return string|null
+     */
+    public function extractChargeIdFromOrder(OrderInterface $order)
+    {
+        $transactionId = (string)$order->getPayment()->getLastTransId();
+        if ($transactionId === '') {
+            return null;
+        }
+
+        foreach (['-capture', '-void'] as $suffix) {
+            if (substr($transactionId, -strlen($suffix)) === $suffix) {
+                return substr($transactionId, 0, -strlen($suffix));
+            }
+        }
+
+        return $transactionId;
+    }
+}

--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -65,6 +65,19 @@ class SendEmail
                     !empty($subject->getStatusHistories()) &&
                     !$subject->getEmailSent()
                     ) {
+                    // Order cancellation flow can pass through Processing transiently
+                    foreach ($subject->getAllItems() as $item) {
+                        if ($item->getQtyCanceled() > 0) {
+                            return $result;
+                        }
+                    }
+                    // Cancelling a pending invoice resets the order to Processing
+                    if ($subject->hasInvoices() &&
+                        !((float)$subject->getTotalPaid() > 0) &&
+                        !((float)$subject->getTotalInvoiced() > 0)
+                        ) {
+                        return $result;
+                    }
                     $subject->setCanSendNewEmailFlag(true);
                     $this->orderSender->send($subject);
                 }

--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -73,8 +73,8 @@ class SendEmail
                     }
                     // Cancelling a pending invoice resets the order to Processing
                     if ($subject->hasInvoices() &&
-                        !((float)$subject->getTotalPaid() > 0) &&
-                        !((float)$subject->getTotalInvoiced() > 0)
+                        (float)$subject->getTotalPaid() <= 0 &&
+                        (float)$subject->getTotalInvoiced() <= 0
                         ) {
                         return $result;
                     }


### PR DESCRIPTION
Fixes  [1326](https://bearideas.jira.com/jira/servicedesk/projects/ASD/queues/custom/142/ASD-1326) .

**Issue 1** - Payment captured at Amazon, but the order was cancelled in Magento with a confirmation email already sent
Root cause: after Amazon successfully captured the payment, any error in the remaining order-finalization steps (an API timeout, a transient server error) made the module cancel the order - even though the money was already taken.
The same could happen via the cleanup cron: if a buyer never returned from Amazon's page, the cron completed the payment itself and then cancelled the freshly captured order when a later step failed.

Fix: the module now never cancels an order once its payment is paid or captured.
Errors that occur after capture are logged for review; the order stays in Processing. The guard covers both the normal checkout return and the cleanup cron.

Verification: I simulated a post-capture failure (forced exception after the capture call).

Scenarios:
1. Buyer returns normally, failure after capture - Order stays Processing, paid and invoiced; failure only logged.
2. Buyer never returns; cleanup cron completes the payment, then failure - Order ends Processing, invoice paid, single confirmation email.

**Issue 2** - Payment never captured, order shows a balance due and the customer still received a confirmation email

Root cause: when a payment was declined asynchronously, the order was cancelled - but cancelling its pending invoice makes Magento briefly flip the order through Processing, and that transition fired the order-confirmation email. 
The customer received a confirmation for an unpaid, already-cancelled order.

Fix: the confirmation email is suppressed during order and invoice cancellation. It is now sent only alongside a successful payment.

Verification: using Amazon's sandbox decline card (async decline).

Scenarios:
1. Order placed - Payment Review, no email
2. Async decline processed - Order cancelled, "payment declined" email
3. Pending invoice cancelled - No confirmation email

**Issue 3** - Payment never captured, order stuck in Payment Review forever
Root cause: two defects in the cleanup cron.

Whenever the cron encountered an abandoned checkout whose Amazon session ended Cancelled, it crashed with a fatal PHP error. Because the same crash repeated on every 5-minute run, every stuck order queued behind that session stayed in Payment Review indefinitely. The cron's eligibility query matched on the order's status label instead of its state. Any order given a custom status became permanently invisible to the cleanup - while at least one long-cancelled historical order was matched incorrectly and re-processed on every run.
Fix: the fatal error is resolved, and the cleanup query now matches on order state, so custom status labels no longer hide orders from it.

Verification: abandoned checkout with the sandbox decline card.

Scenarios:
1. Cleanup cron runs - Order cancelled cleanly, no email, no error
2. Order given a custom status while in Payment Review - Picked up and resolved normally