### PR TITLE
Asd 1325 - release 

### DIFF
--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -161,6 +161,12 @@ class CleanUpIncompleteSessions
         $order = $this->loadOrder($orderId);
 
         if ($order) {
+            if ($this->isOrderPaidOrCaptured($order)) {
+                $this->logger->info(
+                    self::LOG_PREFIX . 'Skip cancellation for already paid/captured order: ' . $orderId
+                );
+                return;
+            }
             $this->checkoutSessionManagement->cancelOrder($order, null, $reasonMessage);
         } else {
             $this->logger->error(self::LOG_PREFIX . 'Order not found for ID: ' . $orderId);
@@ -181,5 +187,55 @@ class CleanUpIncompleteSessions
             $this->logger->error(self::LOG_PREFIX . 'Error loading order: ' . $e->getMessage());
             return null;
         }
+    }
+
+    /**
+     * Prevent cancellation if payment is already completed.
+     *
+     * @param OrderInterface $order
+     * @return bool
+     */
+    private function isOrderPaidOrCaptured(OrderInterface $order)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        $chargeId = $this->extractChargeIdFromOrder($order);
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonPayAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->logger->error(self::LOG_PREFIX . 'Unable to verify charge state before cancel. chargeId: '
+                . $chargeId . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve charge ID from payment transaction data where possible.
+     *
+     * @param OrderInterface $order
+     * @return string|null
+     */
+    private function extractChargeIdFromOrder(OrderInterface $order)
+    {
+        $transactionId = (string)$order->getPayment()->getLastTransId();
+        if ($transactionId === '') {
+            return null;
+        }
+
+        foreach (['-capture', '-void'] as $suffix) {
+            if (substr($transactionId, -strlen($suffix)) === $suffix) {
+                return substr($transactionId, 0, -strlen($suffix));
+            }
+        }
+
+        return $transactionId;
     }
 }

--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -20,6 +20,7 @@ use Amazon\Pay\Helper\Transaction as TransactionHelper;
 use Amazon\Pay\Logger\Logger;
 use Amazon\Pay\Model\Adapter\AmazonPayAdapter;
 use Amazon\Pay\Model\CheckoutSessionManagement;
+use Amazon\Pay\Model\Payment\PaidOrderGuard;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Amazon\Pay\Model\AsyncManagement\Charge as AsyncCharge;
@@ -63,12 +64,18 @@ class CleanUpIncompleteSessions
     protected $asyncCharge;
 
     /**
+     * @var PaidOrderGuard
+     */
+    protected $paidOrderGuard;
+
+    /**
      * @param TransactionHelper $transactionHelper
      * @param Logger $logger
      * @param AmazonPayAdapter $amazonPayAdapter
      * @param CheckoutSessionManagement $checkoutSessionManagement
      * @param OrderRepositoryInterface $orderRepository
      * @param AsyncCharge $asyncCharge
+     * @param PaidOrderGuard $paidOrderGuard
      */
     public function __construct(
         TransactionHelper $transactionHelper,
@@ -76,7 +83,8 @@ class CleanUpIncompleteSessions
         AmazonPayAdapter $amazonPayAdapter,
         CheckoutSessionManagement $checkoutSessionManagement,
         OrderRepositoryInterface $orderRepository,
-        AsyncCharge $asyncCharge
+        AsyncCharge $asyncCharge,
+        PaidOrderGuard $paidOrderGuard
     ) {
         $this->transactionHelper = $transactionHelper;
         $this->logger = $logger;
@@ -84,6 +92,7 @@ class CleanUpIncompleteSessions
         $this->checkoutSessionManagement = $checkoutSessionManagement;
         $this->orderRepository = $orderRepository;
         $this->asyncCharge = $asyncCharge;
+        $this->paidOrderGuard = $paidOrderGuard;
     }
 
     /**
@@ -161,7 +170,7 @@ class CleanUpIncompleteSessions
         $order = $this->loadOrder($orderId);
 
         if ($order) {
-            if ($this->isOrderPaidOrCaptured($order)) {
+            if ($this->paidOrderGuard->isOrderPaidOrCaptured($order)) {
                 $this->logger->info(
                     self::LOG_PREFIX . 'Skip cancellation for already paid/captured order: ' . $orderId
                 );
@@ -189,53 +198,4 @@ class CleanUpIncompleteSessions
         }
     }
 
-    /**
-     * Prevent cancellation if payment is already completed.
-     *
-     * @param OrderInterface $order
-     * @return bool
-     */
-    private function isOrderPaidOrCaptured(OrderInterface $order)
-    {
-        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
-            return true;
-        }
-
-        $chargeId = $this->extractChargeIdFromOrder($order);
-        if (!$chargeId) {
-            return false;
-        }
-
-        try {
-            $charge = $this->amazonPayAdapter->getCharge($order->getStoreId(), $chargeId);
-            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
-        } catch (\Exception $e) {
-            $this->logger->error(self::LOG_PREFIX . 'Unable to verify charge state before cancel. chargeId: '
-                . $chargeId . ' Error: ' . $e->getMessage());
-        }
-
-        return false;
-    }
-
-    /**
-     * Resolve charge ID from payment transaction data where possible.
-     *
-     * @param OrderInterface $order
-     * @return string|null
-     */
-    private function extractChargeIdFromOrder(OrderInterface $order)
-    {
-        $transactionId = (string)$order->getPayment()->getLastTransId();
-        if ($transactionId === '') {
-            return null;
-        }
-
-        foreach (['-capture', '-void'] as $suffix) {
-            if (substr($transactionId, -strlen($suffix)) === $suffix) {
-                return substr($transactionId, 0, -strlen($suffix));
-            }
-        }
-
-        return $transactionId;
-    }
 }

--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -130,6 +130,27 @@ class CleanUpIncompleteSessions
                 $transactionData['store_id'],
                 $checkoutSessionId
             );
+            // On API errors the adapter does not throw; it returns the decoded error
+            // body with the HTTP status attached, and statusDetails is absent
+            $status = (int) ($amazonSession['status'] ?? 200);
+            if (!in_array($status, [200, 201])) {
+                if ($status === 404) {
+                    $logMessage = 'Checkout session no longer exists (404 ResourceNotFound), ';
+                    $logMessage .= 'cancelling order and closing transaction: ' . $checkoutSessionId;
+                    $this->logger->info(self::LOG_PREFIX . $logMessage);
+                    $this->cancelOrder(
+                        $orderId,
+                        'The Amazon Pay checkout session expired or no longer exists.'
+                    );
+                    $this->transactionHelper->closeTransaction($transactionData['transaction_id']);
+                } else {
+                    $logMessage = 'Unexpected status ' . $status . ' fetching checkout session: ';
+                    $logMessage .= $checkoutSessionId;
+                    $this->logger->error(self::LOG_PREFIX . $logMessage);
+                }
+                return;
+            }
+
             $state = $amazonSession['statusDetails']['state'] ?? false;
             switch ($state) {
                 case self::SESSION_STATUS_STATE_CANCELED:

--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -23,6 +23,7 @@ use Amazon\Pay\Model\CheckoutSessionManagement;
 use Amazon\Pay\Model\Payment\PaidOrderGuard;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
 use Amazon\Pay\Model\AsyncManagement\Charge as AsyncCharge;
 
 class CleanUpIncompleteSessions
@@ -165,7 +166,28 @@ class CleanUpIncompleteSessions
                     $logMessage = 'Checkout session Open, completing: ';
                     $logMessage .= $checkoutSessionId;
                     $this->logger->debug(self::LOG_PREFIX . $logMessage);
-                    $this->checkoutSessionManagement->completeCheckoutSession($checkoutSessionId, null, $orderId);
+                    try {
+                        $this->checkoutSessionManagement->completeCheckoutSession(
+                            $checkoutSessionId,
+                            null,
+                            $orderId
+                        );
+                    } catch (\Exception $e) {
+                        // completeCheckoutSession cancels an unpaid order when completion
+                        // fails (e.g. the quote was purged). If it did, close the still-open
+                        // transaction so the canceled order is not left with a dangling one,
+                        // mirroring the Canceled/404 branches. Otherwise rethrow so genuine
+                        // failures are logged and retried.
+                        $order = $this->loadOrder($orderId);
+                        if ($order && $order->getState() === Order::STATE_CANCELED) {
+                            $logMessage = 'Order canceled during completion, closing transaction: ';
+                            $logMessage .= $checkoutSessionId;
+                            $this->logger->info(self::LOG_PREFIX . $logMessage);
+                            $this->transactionHelper->closeTransaction($transactionData['transaction_id']);
+                        } else {
+                            throw $e;
+                        }
+                    }
                     break;
                 case self::SESSION_STATUS_STATE_COMPLETED:
                     $logMessage = 'Checkout session Completed, nothing more needed: ';

--- a/Helper/Transaction.php
+++ b/Helper/Transaction.php
@@ -110,8 +110,9 @@ class Transaction
             )
             // No async record pending
             ->where('apa.pending_action IS NULL')
-            // Order awaiting payment
-            ->where("so.status = ?", Order::STATE_PAYMENT_REVIEW)
+            // Order awaiting payment; match on state so orders with custom
+            // statuses assigned by third-party order management are not missed
+            ->where("so.state = ?", Order::STATE_PAYMENT_REVIEW)
             // A transaction is not complete
             ->where('spt.is_closed <> ?', 1)
             // Delay processing new orders

--- a/Model/AsyncManagement/Charge.php
+++ b/Model/AsyncManagement/Charge.php
@@ -101,7 +101,7 @@ class Charge extends AbstractOperation
         \Amazon\Pay\Model\AmazonConfig $amazonConfig,
         \Magento\Framework\Event\ManagerInterface $eventManager
     ) {
-        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder);
+        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder, $asyncLogger);
         $this->amazonAdapter = $amazonAdapter;
         $this->asyncLogger = $asyncLogger;
         $this->invoiceRepository = $invoiceRepository;

--- a/Model/AsyncManagement/Charge.php
+++ b/Model/AsyncManagement/Charge.php
@@ -209,6 +209,14 @@ class Charge extends AbstractOperation
      */
     public function decline($order, $chargeId, $detail)
     {
+        if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+            $this->asyncLogger->warning(
+                'Skip decline cancellation for already paid/captured Order #' . $order->getIncrementId()
+                    . ' chargeId: ' . $chargeId
+            );
+            return;
+        }
+
         $invoice = $this->loadInvoice($chargeId, $order);
         if ($invoice) {
             $invoice->cancel();
@@ -259,6 +267,13 @@ class Charge extends AbstractOperation
      */
     public function cancel($order, $detail)
     {
+        if ($this->isOrderPaidOrCaptured($order)) {
+            $this->asyncLogger->warning(
+                'Skip async cancel for already paid/captured Order #' . $order->getIncrementId()
+            );
+            return;
+        }
+
         if (!$order->isCanceled()) {
             $order->addStatusHistoryComment($detail['reasonCode'] . ' - ' . $detail['reasonDescription']);
             $order->cancel();
@@ -367,5 +382,56 @@ class Charge extends AbstractOperation
             $order->addStatusHistoryComment($errorMessage);
             $order->save();
         }
+    }
+
+    /**
+     * Prevent cancellation if payment is already completed.
+     *
+     * @param OrderInterface $order
+     * @param string|null $chargeId
+     * @return bool
+     */
+    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        $chargeId = $chargeId ?: $this->extractChargeIdFromOrder($order);
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->asyncLogger->error('Unable to verify charge state before cancel. chargeId: ' . $chargeId
+                . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve charge ID from payment transaction data where possible.
+     *
+     * @param OrderInterface $order
+     * @return string|null
+     */
+    private function extractChargeIdFromOrder(OrderInterface $order)
+    {
+        $transactionId = (string)$order->getPayment()->getLastTransId();
+        if ($transactionId === '') {
+            return null;
+        }
+
+        foreach (['-capture', '-void'] as $suffix) {
+            if (substr($transactionId, -strlen($suffix)) === $suffix) {
+                return substr($transactionId, 0, -strlen($suffix));
+            }
+        }
+
+        return $transactionId;
     }
 }

--- a/Model/AsyncManagement/Charge.php
+++ b/Model/AsyncManagement/Charge.php
@@ -72,6 +72,11 @@ class Charge extends AbstractOperation
     private $eventManager;
 
     /**
+     * @var \Amazon\Pay\Model\Payment\PaidOrderGuard
+     */
+    private $paidOrderGuard;
+
+    /**
      * Charge constructor.
      *
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
@@ -86,6 +91,7 @@ class Charge extends AbstractOperation
      * @param \Magento\Backend\Model\UrlInterface $urlBuilder
      * @param \Amazon\Pay\Model\AmazonConfig $amazonConfig
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
+     * @param \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
      */
     public function __construct(
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
@@ -99,7 +105,8 @@ class Charge extends AbstractOperation
         \Magento\Framework\Notification\NotifierInterface $notifier,
         \Magento\Backend\Model\UrlInterface $urlBuilder,
         \Amazon\Pay\Model\AmazonConfig $amazonConfig,
-        \Magento\Framework\Event\ManagerInterface $eventManager
+        \Magento\Framework\Event\ManagerInterface $eventManager,
+        \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
     ) {
         parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder, $asyncLogger);
         $this->amazonAdapter = $amazonAdapter;
@@ -111,6 +118,7 @@ class Charge extends AbstractOperation
         $this->urlBuilder = $urlBuilder;
         $this->amazonConfig = $amazonConfig;
         $this->eventManager = $eventManager;
+        $this->paidOrderGuard = $paidOrderGuard;
     }
 
     /**
@@ -209,7 +217,7 @@ class Charge extends AbstractOperation
      */
     public function decline($order, $chargeId, $detail)
     {
-        if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+        if ($this->paidOrderGuard->isOrderPaidOrCaptured($order, $chargeId)) {
             $this->asyncLogger->warning(
                 'Skip decline cancellation for already paid/captured Order #' . $order->getIncrementId()
                     . ' chargeId: ' . $chargeId
@@ -267,7 +275,7 @@ class Charge extends AbstractOperation
      */
     public function cancel($order, $detail)
     {
-        if ($this->isOrderPaidOrCaptured($order)) {
+        if ($this->paidOrderGuard->isOrderPaidOrCaptured($order)) {
             $this->asyncLogger->warning(
                 'Skip async cancel for already paid/captured Order #' . $order->getIncrementId()
             );
@@ -384,54 +392,4 @@ class Charge extends AbstractOperation
         }
     }
 
-    /**
-     * Prevent cancellation if payment is already completed.
-     *
-     * @param OrderInterface $order
-     * @param string|null $chargeId
-     * @return bool
-     */
-    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
-    {
-        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
-            return true;
-        }
-
-        $chargeId = $chargeId ?: $this->extractChargeIdFromOrder($order);
-        if (!$chargeId) {
-            return false;
-        }
-
-        try {
-            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
-            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
-        } catch (\Exception $e) {
-            $this->asyncLogger->error('Unable to verify charge state before cancel. chargeId: ' . $chargeId
-                . ' Error: ' . $e->getMessage());
-        }
-
-        return false;
-    }
-
-    /**
-     * Resolve charge ID from payment transaction data where possible.
-     *
-     * @param OrderInterface $order
-     * @return string|null
-     */
-    private function extractChargeIdFromOrder(OrderInterface $order)
-    {
-        $transactionId = (string)$order->getPayment()->getLastTransId();
-        if ($transactionId === '') {
-            return null;
-        }
-
-        foreach (['-capture', '-void'] as $suffix) {
-            if (substr($transactionId, -strlen($suffix)) === $suffix) {
-                return substr($transactionId, 0, -strlen($suffix));
-            }
-        }
-
-        return $transactionId;
-    }
 }

--- a/Model/AsyncManagement/Refund.php
+++ b/Model/AsyncManagement/Refund.php
@@ -74,7 +74,7 @@ class Refund extends AbstractOperation
         \Magento\Framework\Notification\NotifierInterface $notifier,
         \Magento\Backend\Model\UrlInterface $urlBuilder
     ) {
-        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder);
+        parent::__construct($orderRepository, $transactionRepository, $searchCriteriaBuilder, $asyncLogger);
         $this->amazonAdapter = $amazonAdapter;
         $this->asyncLogger = $asyncLogger;
         $this->invoiceService = $invoiceService;

--- a/Model/AsyncUpdater.php
+++ b/Model/AsyncUpdater.php
@@ -105,6 +105,10 @@ class AsyncUpdater
             $this->logger->error($e);
             $this->asyncLogger->error($e);
             $async->getResource()->rollBack();
+        } catch (\Throwable $e) {
+            $this->logger->error('An error occurred during the async transaction process: ' . $e->getMessage());
+            $this->asyncLogger->error($e);
+            $async->getResource()->rollBack();
         }
     }
 

--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -26,6 +26,7 @@ use Amazon\Pay\Model\Customer\CompositeMatcher as Matcher;
 use Amazon\Pay\Api\Data\AmazonCustomerInterface;
 use Amazon\Pay\Model\Exception\OrderFailureException;
 use Magento\Quote\Api\Data\CartInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Webapi\Exception as WebapiException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Customer\Model\CustomerRegistry;
@@ -696,7 +697,14 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
     public function cancelOrder($order, $quote = null, $reasonMessage = '')
     {
         if (!$quote) {
-            $quote = $this->getQuote($order);
+            // The quote may have been purged (e.g. aged orders cleaned up by the
+            // clean_quotes cron). Cancellation itself does not need it, so fall back
+            // to null and skip the subscription check below.
+            try {
+                $quote = $this->getQuote($order);
+            } catch (NoSuchEntityException $e) {
+                $quote = null;
+            }
         }
 
         // set order as cancelled
@@ -725,7 +733,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
 
         $order->save();
 
-        if ($this->subscriptionManager->hasSubscription($quote)) {
+        if ($quote && $this->subscriptionManager->hasSubscription($quote)) {
             $this->subscriptionManager->cancel($order);
         }
     }
@@ -776,6 +784,11 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
         $result = [
             'success' => false
         ];
+
+        // Initialize so the catch block below never references an unset variable
+        // when getQuote() throws (purged quote).
+        $order = null;
+        $quote = null;
 
         try {
             $order = $this->orderRepository->get($orderId);

--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -792,11 +792,20 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
 
         } catch (\Exception $e) {
             if (isset($order)) {
-                $this->closeChargePermission($amazonSessionId, $order, $e);
-                $session = $this->getAmazonSession($amazonSessionId);
-                $cancelledMessage = $this->getCanceledMessage($session);
-                $this->cancelOrder($order, $quote, $cancelledMessage);
-                $this->magentoCheckoutSession->restoreQuote();
+                if ($this->isOrderPaidOrCaptured($order)) {
+                    $this->logger->error(
+                        'Checkout completion failed after payment succeeded; order not canceled. '
+                        . 'amazonSessionId: ' . $amazonSessionId
+                        . ' orderId: ' . $order->getEntityId()
+                        . ' Error: ' . $e->getMessage()
+                    );
+                } else {
+                    $this->closeChargePermission($amazonSessionId, $order, $e);
+                    $session = $this->getAmazonSession($amazonSessionId);
+                    $cancelledMessage = $this->getCanceledMessage($session);
+                    $this->cancelOrder($order, $quote, $cancelledMessage);
+                    $this->magentoCheckoutSession->restoreQuote();
+                }
             }
 
             throw $e;
@@ -1296,6 +1305,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
      */
     private function handlePayment($amazonSessionId, $amazonCheckoutResult, $order, $quote)
     {
+        $chargeId = null;
         try {
             // $amazonCheckoutResult holds success flag and actual result from api call
             $amazonCompleteCheckoutResult = $amazonCheckoutResult['amazonCompleteCheckoutResult'];
@@ -1321,26 +1331,27 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             }
             $amazonCharge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
 
-            // @TODO: for recurring, the order incremenet ID needs to be updated on the charge
-            //Send merchantReferenceId to Amazon
-            $this->amazonAdapter->updateChargePermission(
-                $order->getStoreId(),
-                $amazonCharge['chargePermissionId'],
-                ['merchantReferenceId' => $order->getIncrementId()]
-            );
-
             $chargeState = $amazonCharge['statusDetails']['state'];
 
             switch ($chargeState) {
                 case 'AuthorizationInitiated':
+                case 'CaptureInitiated':
                     $payment->setIsTransactionClosed(false);
                     $this->setPending($payment);
                     $transaction->setIsClosed(false);
                     $this->asyncManagement->queuePendingAuthorization($chargeId);
                     break;
                 case 'Authorized':
-                    $this->setProcessing($payment);
-                    if ($this->amazonConfig->getAuthorizationMode() == AuthorizationMode::SYNC_THEN_ASYNC) {
+                    if ($this->amazonConfig->getPaymentAction() == PaymentAction::AUTHORIZE_AND_CAPTURE) {
+                        $payment->setIsTransactionClosed(false);
+                        $this->setPending($payment);
+                        $transaction->setIsClosed(false);
+                        $this->asyncManagement->queuePendingAuthorization($chargeId);
+                    } else {
+                        $this->setProcessing($payment);
+                    }
+                    if ($this->amazonConfig->getPaymentAction() == PaymentAction::AUTHORIZE &&
+                        $this->amazonConfig->getAuthorizationMode() == AuthorizationMode::SYNC_THEN_ASYNC) {
                         $this->addCaptureComment($payment, $amazonCharge['chargePermissionId']);
                     }
                     break;
@@ -1363,14 +1374,47 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             );
 
             $this->updateTransactionId($chargeId, $payment, $transaction);
-            $this->updateVaultToken(
-                $amazonSessionId,
-                $amazonCompleteCheckoutResult['chargePermissionId'],
-                $quote,
-                $order
-            );
+
+            // Best-effort update only; should never fail checkout after payment succeeds.
+            try {
+                $this->amazonAdapter->updateChargePermission(
+                    $order->getStoreId(),
+                    $amazonCharge['chargePermissionId'],
+                    ['merchantReferenceId' => $order->getIncrementId()]
+                );
+            } catch (\Exception $e) {
+                $this->logger->error('Unable to update charge permission metadata. chargeId: ' . $chargeId
+                    . ' Error: ' . $e->getMessage());
+            }
+
+            // Best-effort token maintenance only; payment result should not be reversed if this fails.
+            try {
+                $this->updateVaultToken(
+                    $amazonSessionId,
+                    $amazonCompleteCheckoutResult['chargePermissionId'],
+                    $quote,
+                    $order
+                );
+            } catch (\Exception $e) {
+                $this->logger->error('Unable to update vault token. chargeId: ' . $chargeId
+                    . ' Error: ' . $e->getMessage());
+            }
             return ['success'=>true];
         } catch (\Exception $e) {
+            if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+                $this->logger->error(
+                    'Checkout completion encountered a post-payment error; order not canceled. '
+                    . 'amazonSessionId: ' . $amazonSessionId
+                    . ' chargeId: ' . ($chargeId ?: 'n/a')
+                    . ' orderId: ' . $order->getEntityId()
+                    . ' Error: ' . $e->getMessage()
+                );
+                return [
+                    'success' => true,
+                    'order_id' => $order->getEntityId()
+                ];
+            }
+
             $this->closeChargePermission($amazonSessionId, $order, $e);
 
             $session = $this->amazonAdapter->getCheckoutSession(
@@ -1390,6 +1434,34 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
                 $logEntryDetails
             );
         }
+    }
+
+    /**
+     * Check if payment succeeded enough to prevent canceling the order on follow-up errors.
+     *
+     * @param OrderInterface $order
+     * @param string|null $chargeId
+     * @return bool
+     */
+    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->logger->error('Unable to verify charge state before order cancel. chargeId: ' . $chargeId
+                . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
     }
 
     /**

--- a/Model/CheckoutSessionManagement.php
+++ b/Model/CheckoutSessionManagement.php
@@ -236,6 +236,11 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
     private $updateCouponUsages;
 
     /**
+     * @var \Amazon\Pay\Model\Payment\PaidOrderGuard
+     */
+    private $paidOrderGuard;
+
+    /**
      * CheckoutSessionManagement constructor.
      *
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
@@ -273,6 +278,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
      * @param Session $session
      * @param Translate $translationRenderer
      * @param UpdateCouponUsages $updateCouponUsages
+     * @param \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
      */
     public function __construct(
         \Magento\Store\Model\StoreManagerInterface $storeManager,
@@ -309,7 +315,8 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
         \Amazon\Pay\Logger\Logger $logger,
         Session $session,
         Translate $translationRenderer,
-        UpdateCouponUsages $updateCouponUsages
+        UpdateCouponUsages $updateCouponUsages,
+        \Amazon\Pay\Model\Payment\PaidOrderGuard $paidOrderGuard
     ) {
         $this->storeManager = $storeManager;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
@@ -346,6 +353,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
         $this->session = $session;
         $this->translationRenderer = $translationRenderer;
         $this->updateCouponUsages = $updateCouponUsages;
+        $this->paidOrderGuard = $paidOrderGuard;
     }
 
     /**
@@ -792,7 +800,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
 
         } catch (\Exception $e) {
             if (isset($order)) {
-                if ($this->isOrderPaidOrCaptured($order)) {
+                if ($this->paidOrderGuard->isOrderPaidOrCaptured($order, null, false)) {
                     $this->logger->error(
                         'Checkout completion failed after payment succeeded; order not canceled. '
                         . 'amazonSessionId: ' . $amazonSessionId
@@ -1401,7 +1409,7 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
             }
             return ['success'=>true];
         } catch (\Exception $e) {
-            if ($this->isOrderPaidOrCaptured($order, $chargeId)) {
+            if ($this->paidOrderGuard->isOrderPaidOrCaptured($order, $chargeId, false)) {
                 $this->logger->error(
                     'Checkout completion encountered a post-payment error; order not canceled. '
                     . 'amazonSessionId: ' . $amazonSessionId
@@ -1434,34 +1442,6 @@ class CheckoutSessionManagement implements \Amazon\Pay\Api\CheckoutSessionManage
                 $logEntryDetails
             );
         }
-    }
-
-    /**
-     * Check if payment succeeded enough to prevent canceling the order on follow-up errors.
-     *
-     * @param OrderInterface $order
-     * @param string|null $chargeId
-     * @return bool
-     */
-    private function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null)
-    {
-        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
-            return true;
-        }
-
-        if (!$chargeId) {
-            return false;
-        }
-
-        try {
-            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
-            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
-        } catch (\Exception $e) {
-            $this->logger->error('Unable to verify charge state before order cancel. chargeId: ' . $chargeId
-                . ' Error: ' . $e->getMessage());
-        }
-
-        return false;
     }
 
     /**

--- a/Model/Payment/PaidOrderGuard.php
+++ b/Model/Payment/PaidOrderGuard.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright © Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Amazon\Pay\Model\Payment;
+
+use Amazon\Pay\Logger\Logger;
+use Amazon\Pay\Model\Adapter\AmazonPayAdapter;
+use Magento\Sales\Api\Data\OrderInterface;
+
+/**
+ * Guards order cancellation paths against voiding orders whose payment already succeeded.
+ */
+class PaidOrderGuard
+{
+    /**
+     * @var AmazonPayAdapter
+     */
+    private $amazonAdapter;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @param AmazonPayAdapter $amazonAdapter
+     * @param Logger $logger
+     */
+    public function __construct(
+        AmazonPayAdapter $amazonAdapter,
+        Logger $logger
+    ) {
+        $this->amazonAdapter = $amazonAdapter;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Check if payment succeeded enough to prevent canceling the order on follow-up errors.
+     *
+     * Checks order totals first; falls back to a live Amazon charge state lookup. When no
+     * charge ID is given, $resolveChargeIdFromOrder controls whether one is derived from the
+     * payment's last transaction ID (checkout-flow callers pass false: their last transaction
+     * may be a checkout-session ID, not a charge).
+     *
+     * @param OrderInterface $order
+     * @param string|null $chargeId
+     * @param bool $resolveChargeIdFromOrder
+     * @return bool
+     */
+    public function isOrderPaidOrCaptured(OrderInterface $order, $chargeId = null, $resolveChargeIdFromOrder = true)
+    {
+        if ((float)$order->getTotalPaid() > 0 || (float)$order->getTotalDue() <= 0.0001) {
+            return true;
+        }
+
+        if (!$chargeId && $resolveChargeIdFromOrder) {
+            $chargeId = $this->extractChargeIdFromOrder($order);
+        }
+        if (!$chargeId) {
+            return false;
+        }
+
+        try {
+            $charge = $this->amazonAdapter->getCharge($order->getStoreId(), $chargeId);
+            return ($charge['statusDetails']['state'] ?? '') === 'Captured';
+        } catch (\Exception $e) {
+            $this->logger->error('Unable to verify charge state before cancel. chargeId: ' . $chargeId
+                . ' Error: ' . $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve charge ID from payment transaction data where possible.
+     *
+     * @param OrderInterface $order
+     * @return string|null
+     */
+    public function extractChargeIdFromOrder(OrderInterface $order)
+    {
+        $transactionId = (string)$order->getPayment()->getLastTransId();
+        if ($transactionId === '') {
+            return null;
+        }
+
+        foreach (['-capture', '-void'] as $suffix) {
+            if (substr($transactionId, -strlen($suffix)) === $suffix) {
+                return substr($transactionId, 0, -strlen($suffix));
+            }
+        }
+
+        return $transactionId;
+    }
+}

--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -65,6 +65,19 @@ class SendEmail
                     !empty($subject->getStatusHistories()) &&
                     !$subject->getEmailSent()
                     ) {
+                    // Order cancellation flow can pass through Processing transiently
+                    foreach ($subject->getAllItems() as $item) {
+                        if ($item->getQtyCanceled() > 0) {
+                            return $result;
+                        }
+                    }
+                    // Cancelling a pending invoice resets the order to Processing
+                    if ($subject->hasInvoices() &&
+                        !((float)$subject->getTotalPaid() > 0) &&
+                        !((float)$subject->getTotalInvoiced() > 0)
+                        ) {
+                        return $result;
+                    }
                     $subject->setCanSendNewEmailFlag(true);
                     $this->orderSender->send($subject);
                 }

--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -73,8 +73,8 @@ class SendEmail
                     }
                     // Cancelling a pending invoice resets the order to Processing
                     if ($subject->hasInvoices() &&
-                        !((float)$subject->getTotalPaid() > 0) &&
-                        !((float)$subject->getTotalInvoiced() > 0)
+                        (float)$subject->getTotalPaid() <= 0 &&
+                        (float)$subject->getTotalInvoiced() <= 0
                         ) {
                         return $result;
                     }


### PR DESCRIPTION
Fixes [ASD-1325](https://bearideas.jira.com/jira/servicedesk/projects/ASD/queues/custom/147/ASD-1325) .

## Problem

When an Amazon checkout session expires server-side, `getCheckoutSession()` returns a `404 ResourceNotFound` error array instead of throwing. The cleanup cron finds no `statusDetails` in it, silently does nothing - so the order stays in `payment_review` with an open transaction and is re-fetched every 5 minutes forever, flooding `var/log/paywithamazon.log`.

A second failure showed up on the real aged backlog: orders 11–18 months old whose quote had since been purged. Even with the 404 handled, cancellation still threw before doing anything, because `cancelOrder()` looks up the order's quote first
(`getQuote()` → `NoSuchEntityException`). The same purged-quote lookup also broke the `Open`-session path, where `completeCheckoutSession()` referenced an unset `$quote` in its catch (`Undefined variable $quote`). In both cases the order was never cancelled and the transaction never closed, so the loop and log flooding persisted for exactly the orders this is meant to clean up.

## Reproduction

Placed an order with the return redirect blocked (order stuck in `payment_review`), then:
- pointed its transaction at a nonexistent session id → the cron logged the exact `404` error from the issue and repeated it on every run without cancelling; and
- additionally deleted the order's quote to mimic the aged backlog → cancellation failed with `No such entity with cartId` (404 path) and `Undefined variable $quote` (Open path).

## Fix

Make cancellation independent of the quote, which may no longer exist:
- `cancelOrder()` wraps the `getQuote()` lookup in try/catch (falls back to `null`) and guards the subscription check with `if ($quote)`.
- `completeCheckoutSession()` initializes `$order`/`$quote` before the `try` so its catch never references an unset variable.
- The cron's `Open` branch closes the transaction when completion ends in cancellation, matching the `Canceled`/`404` branches.

## Covered cases

- Session expired (`404`) → order cancelled with reason, transaction closed.
- Session `Canceled` → order cancelled, transaction closed (unchanged).
- Aged order, quote purged, session `404` → cancelled + closed, no `No such entity` error.
- Aged order, quote purged, session `Open` → cancelled + closed, no `Undefined variable $quote`.
- Paid/captured order → never cancelled (`PaidOrderGuard`).
- Any other non-2xx status → logged explicitly, not silently skipped.
- Order with an intact quote → completes normally on `Open`; no behaviour change.

## Verification

After the fix, for each case above the order is cancelled with a reason comment, the transaction is closed (`is_closed = 1`), and the next cron run no longer selects it. Verified on sandbox (Adobe Commerce 2.4.7-p10, module 5.18.x) for both the `Open` and `404` branches with the quote purged.

[ASD-1325]: https://bearideas.jira.com/browse/ASD-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ