### PR TITLE
ASD-1329 Fix deprecation when payment region is null in getCurrencyCode

### DIFF
--- a/Model/AmazonConfig.php
+++ b/Model/AmazonConfig.php
@@ -298,7 +298,7 @@ class AmazonConfig
             'jp' => 'JPY'
         ];
 
-        return array_key_exists($paymentRegion, $currencyCodeMap) ? $currencyCodeMap[$paymentRegion] : '';
+        return $currencyCodeMap[(string) $paymentRegion] ?? '';
     }
 
     /**


### PR DESCRIPTION
Fixes [ASD-1329](https://bearideas.jira.com/jira/servicedesk/projects/ASD/queues/custom/147/ASD-1329) .


[ASD-1329]: https://bearideas.jira.com/browse/ASD-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ